### PR TITLE
feat: Adds support for rubocop

### DIFF
--- a/lib/templates/.rspec
+++ b/lib/templates/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -1,0 +1,4 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-performance

--- a/lib/templates/Gemfile.tt
+++ b/lib/templates/Gemfile.tt
@@ -31,6 +31,12 @@ gem 'sidekiq'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Ruby linting and formatting
+gem 'rubocop', require: false
+gem 'rubocop-rails', require: false
+gem 'rubocop-rspec', require: false
+gem 'rubocop-performance', require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/lib/templates/spec/rails_helper.rb.tt
+++ b/lib/templates/spec/rails_helper.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/lib/templates/spec/spec_helper.rb.tt
+++ b/lib/templates/spec/spec_helper.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start 'rails'
 

--- a/lib/templates/spec/support/factory_bot.rb
+++ b/lib/templates/spec/support/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot_rails'
 
 RSpec.configure do |config|

--- a/lib/templates/spec/support/shoulda_matchers.rb
+++ b/lib/templates/spec/support/shoulda_matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shoulda-matchers'
 
 Shoulda::Matchers.configure do |config|

--- a/template.rb
+++ b/template.rb
@@ -88,6 +88,10 @@ def create_dev_procfile
   template 'lib/templates/Procfile.dev', 'Procfile.dev'
 end
 
+def create_rubocop
+  template 'lib/templates/.rubocop.yml', '.rubocop.yml'
+end
+
 source_paths
 create_gitignore
 create_gemfile
@@ -100,4 +104,5 @@ after_bundle do
   config_rspec
   create_spec_support
   create_dev_procfile
+  create_rubocop
 end


### PR DESCRIPTION
Closes #1  

Adds support for rubocop using the rubocop-rails, rubocop-rspec and rubocop-performance extensions.

Fixed linting errors in the template files for specs where there were violations.