### PR TITLE
feat: Dotenv to manage environment variables

### DIFF
--- a/lib/templates/.env.tt
+++ b/lib/templates/.env.tt
@@ -1,0 +1,1 @@
+DATABASE_URI=example

--- a/lib/templates/Gemfile.tt
+++ b/lib/templates/Gemfile.tt
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '<%= RUBY_VERSION %>'
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
 # Use sqlite3 as the database for Active Record

--- a/template.rb
+++ b/template.rb
@@ -92,6 +92,14 @@ def create_rubocop
   template 'lib/templates/.rubocop.yml', '.rubocop.yml'
 end
 
+def create_dotenv
+  template 'lib/templates/.env.tt', '.env'
+end
+
+def create_dotenv_template
+  template 'lib/templates/.env.template.tt', '.env.template'
+end
+
 source_paths
 create_gitignore
 create_gemfile
@@ -105,4 +113,6 @@ after_bundle do
   create_spec_support
   create_dev_procfile
   create_rubocop
+  create_dotenv
+  create_dotenv_template
 end


### PR DESCRIPTION
Adds a .env ERB template
@todo add interpreted env vars for secrets e.g. generate db_uri
Adds a .env.template file
Adds dotenv to Gemfile

Learned about the ability to run `dotenv -t .env` to generate a template file with env vars for sharing.

Closes #15 